### PR TITLE
Change to 2 nodes since IN_USE_ADDRESSES default quota is 8

### DIFF
--- a/gke.tf
+++ b/gke.tf
@@ -9,7 +9,7 @@ variable "gke_password" {
 }
 
 variable "gke_num_nodes" {
-  default     = 3
+  default     = 2
   description = "number of gke nodes"
 }
 


### PR DESCRIPTION
Change based on user reported issue:

> The proposed cluster creates 9 ressources, it's higher than the default quota of IN_USE_ADDRESSES when creating a project on GCP (at least for the the free-tier).
This limit can be increased manually but the error happens in the middle of the tuto, we have to understand it, find the quota on GCP (which is hard for beginners) and wait for the increase demand to be validated.
It's not very comfortable.