### PR TITLE
Update google_container_cluster resource due to k8s v1.18 updates

### DIFF
--- a/gke.tf
+++ b/gke.tf
@@ -17,21 +17,15 @@ variable "gke_num_nodes" {
 resource "google_container_cluster" "primary" {
   name     = "${var.project_id}-gke"
   location = var.region
-
+  
+  # We can't create a cluster with no node pool defined, but we want to only use
+  # separately managed node pools. So we create the smallest possible default
+  # node pool and immediately delete it.
   remove_default_node_pool = true
   initial_node_count       = 1
 
   network    = google_compute_network.vpc.name
   subnetwork = google_compute_subnetwork.subnet.name
-
-  master_auth {
-    username = var.gke_username
-    password = var.gke_password
-
-    client_certificate_config {
-      issue_client_certificate = false
-    }
-  }
 }
 
 # Separately Managed Node Pool


### PR DESCRIPTION
Similar issue reported as: https://github.com/hashicorp/learn-terraform-pipelines-k8s/issues/5.

Removing `master_auth` block addresses this concern.