### PR TITLE
Remove interpolation syntax

### DIFF
--- a/gke.tf
+++ b/gke.tf
@@ -30,7 +30,7 @@ resource "google_container_cluster" "primary" {
 
 # Separately Managed Node Pool
 resource "google_container_node_pool" "primary_nodes" {
-  name       = "${google_container_cluster.primary.name}"
+  name       = google_container_cluster.primary.name
   location   = var.region
   cluster    = google_container_cluster.primary.name
   node_count = var.gke_num_nodes


### PR DESCRIPTION
Terraform 0.11 and earlier required all non-constant expressions to be provided via interpolation syntax, but this pattern is now deprecated.