### PR TITLE
Update kubernetes-dashboard-admin.rbac.yaml

### DIFF
--- a/kubernetes-dashboard-admin.rbac.yaml
+++ b/kubernetes-dashboard-admin.rbac.yaml
@@ -7,6 +7,16 @@ metadata:
   name: admin-user
   namespace: kube-system
 ---
+#Create Secret for ServiceAccount
+apiVersion: v1
+kind: Secret
+metadata:
+  name: admin-user
+  namespace: kube-system
+  annotations:
+    kubernetes.io/service-account.name: "admin-user"
+type: kubernetes.io/service-account-token
+---
 # Create ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Add configuration to declare a secret be made for the service account being created.

In Kubernetes `1.24`, ServiceAccount token secrets are no longer automatically generated. See ["Urgent Upgrade Notes" in the 1.24 changelog file](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#urgent-upgrade-notes):

>The `LegacyServiceAccountTokenNoAutoGeneration` feature gate is beta, and enabled by default. When enabled, Secret API objects containing service account tokens are no longer auto-generated for every ServiceAccount. Use the [TokenRequest](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) API to acquire service account tokens, or if a non-expiring token is required, create a Secret API object for the token controller to populate with a service account token by following this [guide](https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets). ([#108309](https://github.com/kubernetes/kubernetes/pull/108309), [@zshihang](https://github.com/zshihang))

This configuration will ensure the secret is created, which will keep the current steps in the tutorial valid for any of the kubernetes versions `1.24 and newer`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204220321408206