### PR TITLE
Fix issue with Node Pool Version

### DIFF
--- a/gke.tf
+++ b/gke.tf
@@ -42,7 +42,7 @@ resource "google_container_node_pool" "primary_nodes" {
   location   = var.region
   cluster    = google_container_cluster.primary.name
   
-  version = data.google_container_engine_versions.gke_version.release_channel_latest_version["STABLE"]
+  version = data.google_container_engine_versions.gke_version.release_channel_default_version["STABLE"]
   node_count = var.gke_num_nodes
 
   node_config {


### PR DESCRIPTION
Fixing issue https://github.com/hashicorp-education/learn-terraform-provision-gke-cluster/issues/24

Version is pointing to incorrect release channel. Updating the link to reflect the latest state.